### PR TITLE
Added docker-build for container registry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,8 +9,8 @@ on:
       - master
 
 env:
-  REGISTRY: ghcr.io # Change to your container registry if not GitHub's
-  IMAGE_NAME: my-image-name # Replace with the name of your image
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ls25discord
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io # Change to your container registry if not GitHub's
+  IMAGE_NAME: my-image-name # Replace with the name of your image
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and pushing Docker images. The workflow is triggered on pushes and pull requests to the `master` branch.

Key changes include:

* `.github/workflows/docker-build.yml`: 
  - Added a new workflow named "Docker Build" that triggers on push and pull request events to the `master` branch.
  - Defined environment variables for the Docker registry and image name.
  - Included steps for checking out the repository, logging into the container registry, extracting metadata for Docker, and building and pushing the Docker image.