### PR TITLE
Changed branch to main

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ls25discord
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,10 +3,10 @@ name: Docker Build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 env:
   REGISTRY: ghcr.io

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ls25discord",
+  "name": "ls25-discord-bot",
   "version": "0.1.3",
   "description": "A simple discord bot for farming simulator 25",
   "main": "source/Main.ts",


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow file to update the branch name references from `master` to `main`.

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L6-R9): Changed branch name references from `master` to `main` in the `push` and `pull_request` sections.